### PR TITLE
docs: add initial changelog with recent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All significant changes to the project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+- Support for `raw_token` as both `bytes` and `str` in `KeycloakAuthBackend`.
+- New tests that cover both token types.
+
+### Changed
+- Conditional decoding of `raw_token` in `KeycloakAuthBackend` to handle both `bytes` and `str`.
+
+### Fixed
+- Removes unnecessary `.decode()` call for already decoded `str` tokens.
+
+## [1.0.1] - 2024-11-12
+
+### Added
+- Support for different types of `raw_token` (byte strings and regular strings).
+- Additional tests to ensure compatibility with both token types.
+
+### Changed
+- Adaptation of the `KeycloakAuthBackend` class for conditional decoding of `raw_token`.
+- Updated the test cases to include both `bytes` and `str` tokens.
+
+### Fixed
+- Fixed comparison assertion bug in tests by comparing `validated_token` to `claims` instead of `raw_token`.
+
+## [1.0.0] - 2023-09-12
+
+### Added
+- Initial release of the `drf_keycloak` package.
+- Support for keycloak-based authentication in Django REST Framework.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require["dev"] = (
 
 setup(
     name="drf-keycloak",
-    version="v1.0.0",
+    version="v1.0.1",
     url="https://github.com/sascharau/djangorestframework-keycloak",
     license="MIT",
     description="Keycloak authentication plugin for Django REST Framework",


### PR DESCRIPTION
fix(authentication): handle raw_token as bytes or string

- Updated KeycloakAuthBackend to conditionally decode raw_token only if it's bytes.
- Enhanced tests to cover scenarios where raw_token is either bytes or string.
- Ensured compatibility with both byte and string token inputs.
