### PR TITLE
fix: InternalServerError when token is invalid

### DIFF
--- a/drf_keycloak/authentication.py
+++ b/drf_keycloak/authentication.py
@@ -60,8 +60,11 @@ class KeycloakAuthBackend(authentication.BaseAuthentication):
         self.raw_token = self.get_raw_token(header)
         if self.raw_token is None:
             return None
-        validated_token = JWToken(self.raw_token).payload
-        return self.get_user_or_create(validated_token), validated_token
+        try:
+            validated_token = JWToken(self.raw_token).payload
+            return self.get_user_or_create(validated_token), validated_token
+        except APIException as e:
+            return None
 
     def get_user_or_create(self, validated_token):
         """


### PR DESCRIPTION
Detected an issue with this method - when JWT token was invalid (Keycloak returned that token has expired), it thrown an InternalServerError without specifying the reason.