### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ venv/
 .tox/
 coverage.xml
 
+# Test project (not shipped with package)
+test_project/db.sqlite3
+test_project/.env*
+test_project/media/
+test_project/static/
+
 # Miscellaneous
 *.bak
 *.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All significant changes to the project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.0.2] - 2025-06-11
 
 ### Added
 - **Docker Test Environment:** Complete Docker setup with Keycloak integration for testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,30 +7,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Support for `raw_token` as both `bytes` and `str` in `KeycloakAuthBackend`.
-- New tests that cover both token types.
+- **Docker Test Environment:** Complete Docker setup with Keycloak integration for testing
+- **Integration Tests:** Comprehensive test scripts to validate authentication flow
+- **SERVER_URL Configuration:** New `SERVER_URL` setting to separate API calls from JWT issuer validation
+- **Custom Exception Classes:** Added `TokenBackendError` and `TokenBackendExpiredToken` for better error handling
 
-### Changed
-- Conditional decoding of `raw_token` in `KeycloakAuthBackend` to handle both `bytes` and `str`.
+### Changed  
+- **Simplified Configuration:** Replaced `JWKS_URL` with automatic generation from `SERVER_URL`
+- **Removed Keycloak API Verification:** Eliminated `VERIFY_TOKENS_WITH_KEYCLOAK` setting for simplified token validation
+- **Enhanced Error Handling:** Improved exception handling in authentication backend
+- **PyJWT Crypto Support:** Added `PyJWT[crypto]` dependency for RS256 algorithm support
 
 ### Fixed
-- Removes unnecessary `.decode()` call for already decoded `str` tokens.
+- **Docker Network Communication:** Fixed internal vs external URL handling for Docker environments
+- **JWT Algorithm Support:** Resolved "Algorithm 'RS256' could not be found" error
+- **Token Issuer Validation:** Fixed issuer mismatch in Docker environments
+
+### Removed
+- **VERIFY_TOKENS_WITH_KEYCLOAK:** Removed complex dual-validation approach
+- **JWKS_URL:** Auto-generated from SERVER_URL to reduce configuration complexity
 
 ## [1.0.1] - 2024-11-12
 
 ### Added
-- Support for different types of `raw_token` (byte strings and regular strings).
-- Additional tests to ensure compatibility with both token types.
+- Support for different types of `raw_token` (byte strings and regular strings)
+- Additional tests to ensure compatibility with both token types
 
 ### Changed
-- Adaptation of the `KeycloakAuthBackend` class for conditional decoding of `raw_token`.
-- Updated the test cases to include both `bytes` and `str` tokens.
+- Adaptation of the `KeycloakAuthBackend` class for conditional decoding of `raw_token`
+- Updated the test cases to include both `bytes` and `str` tokens
 
 ### Fixed
-- Fixed comparison assertion bug in tests by comparing `validated_token` to `claims` instead of `raw_token`.
+- Fixed comparison assertion bug in tests by comparing `validated_token` to `claims` instead of `raw_token`
 
 ## [1.0.0] - 2023-09-12
 
 ### Added
-- Initial release of the `drf_keycloak` package.
-- Support for keycloak-based authentication in Django REST Framework.
+- Initial release of the `drf_keycloak` package
+- Support for keycloak-based authentication in Django REST Framework

--- a/README.rst
+++ b/README.rst
@@ -31,18 +31,17 @@ You can find a selection of variables in ``drf_keycloak.settings.py``, just over
 .. code-block:: python
 
    KEYCLOAK_CONFIG = {
-       "SERVER_URL": "http://localhost:8080/",
+       "SERVER_URL": "http://localhost:8080/realms/master",
        "REALM": "master",
        "CLIENT_ID": "account",
        "CLIENT_SECRET": None,
        "AUDIENCE": None,
        "ALGORITHM": "RS256",
        "ISSUER": "http://localhost:8080/realms/master",
-       "VERIFY_TOKENS_WITH_KEYCLOAK": False,
        "PERMISSION_PATH": "resource_access.account.roles",
        "USER_ID_FIELD": "username",
        "USER_ID_CLAIM": "preferred_username",
-
+       "VERIFY_SIGNATURE": True,
        # user mapping
        # django keys, keycloak keys
        "CLAIM_MAPPING": {
@@ -53,17 +52,6 @@ You can find a selection of variables in ``drf_keycloak.settings.py``, just over
        },
    }
 
-By setting the variable
-
-.. code-block:: python
-
-   KEYCLOAK_CONFIG = {
-       # ...
-       "VERIFY_TOKENS_WITH_KEYCLOAK": True
-       # ...
-   }
-
-This means that the token is validated with the Keycloak API and locally.
 
 Enable
 ******

--- a/drf_keycloak/api.py
+++ b/drf_keycloak/api.py
@@ -17,7 +17,7 @@ class KeycloakApi:
 
     def __init__(self):
         self.connection = requests.Session()
-        self.base_url = keycloak_settings.ISSUER
+        self.base_url = getattr(keycloak_settings, 'SERVER_URL', keycloak_settings.ISSUER)
         self.client_id = keycloak_settings.CLIENT_ID
         self.realm_name = keycloak_settings.REALM
         self.client_secret_key = keycloak_settings.CLIENT_SECRET or None
@@ -25,7 +25,8 @@ class KeycloakApi:
     @classmethod
     def get_jwks(cls, token):  # pragma: no cover
         """To decode the JWT token, we need a key. We get this from the API"""
-        url = f"{keycloak_settings.ISSUER}/protocol/openid-connect/certs"
+        server_url = getattr(keycloak_settings, 'SERVER_URL', keycloak_settings.ISSUER)
+        url = f"{server_url}/protocol/openid-connect/certs"
         jwks_client = PyJWKClient(url, lifespan=60 * 10)
         signing_key = jwks_client.get_signing_key_from_jwt(token)
         return signing_key.key

--- a/drf_keycloak/exceptions.py
+++ b/drf_keycloak/exceptions.py
@@ -1,0 +1,7 @@
+
+
+class TokenBackendError(Exception):
+    pass
+
+class TokenBackendExpiredToken(TokenBackendError):
+    pass

--- a/drf_keycloak/settings.py
+++ b/drf_keycloak/settings.py
@@ -6,17 +6,17 @@ from rest_framework.settings import APISettings
 
 # default settings from keycloak
 DEFAULT = {
-    "SERVER_URL": "http://localhost:8080/",
+    "SERVER_URL": "http://localhost:8080/realms/master",
     "REALM": "master",
     "CLIENT_ID": "account",
     "CLIENT_SECRET": None,
     "AUDIENCE": None,
     "ALGORITHM": "RS256",
     "ISSUER": "http://localhost:8080/realms/master",
-    "VERIFY_TOKENS_WITH_KEYCLOAK": False,
     "PERMISSION_PATH": "resource_access.account.roles",
     "USER_ID_FIELD": "username",
     "USER_ID_CLAIM": "preferred_username",
+    "VERIFY_SIGNATURE": True,
     # django key, keycloak value
     "CLAIM_MAPPING": {
         "first_name": "given_name",

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     ],
     python_requires=">=3.7",
     extras_require=extras_require,
-    packages=find_packages(exclude=["tests", "tests.*", "licenses", "requirements"]),
+    packages=find_packages(exclude=["tests", "tests.*", "test_project", "test_project.*", "licenses", "requirements"]),
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ setup(
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
@@ -79,6 +81,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
     ],
 )

--- a/test_project/Dockerfile
+++ b/test_project/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy and install the package
+COPY ../setup.py ../setup.cfg ../README.rst ./
+COPY ../drf_keycloak/ ./drf_keycloak/
+
+RUN pip install --upgrade pip && pip install -e .[dev] && pip install PyJWT cryptography
+
+# Copy test files
+COPY ../tests/ ./tests/
+COPY ../pytest.ini ./
+COPY . ./test_project/
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/test_project/Makefile
+++ b/test_project/Makefile
@@ -1,0 +1,42 @@
+.PHONY: help setup-keycloak token curl-test test-integration
+
+help: ## Show this help message
+	@echo "Available commands:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+
+setup-keycloak: ## Setup Keycloak realm and test data
+	@echo "🔧 Setting up Keycloak configuration..."
+	@./scripts/setup-keycloak.sh
+
+token: ## Get a test token from Keycloak
+	@echo "🔑 Getting test token..."
+	@curl -s -X POST 'http://localhost:8080/realms/test-realm/protocol/openid-connect/token' \
+		-H 'Content-Type: application/x-www-form-urlencoded' \
+		-d 'username=testuser' \
+		-d 'password=testpass' \
+		-d 'grant_type=password' \
+		-d 'client_id=test-client' | \
+		python -c "import sys, json; data=json.load(sys.stdin); print('Bearer ' + data['access_token'])" 2>/dev/null || \
+		echo "❌ Failed to get token"
+
+curl-test: ## Test API endpoints with curl
+	@echo "🧪 Testing API endpoints..."
+	@echo "1. Public endpoint:"
+	@curl -s http://localhost:8000/api/public/ | python -m json.tool 2>/dev/null || echo "❌ Django not running"
+	@echo ""
+	@echo "2. Protected endpoint (should fail):"
+	@curl -s http://localhost:8000/api/protected/ 2>/dev/null || echo "✅ Expected 401/403"
+	@echo ""
+	@echo "3. Get token and test protected endpoint:"
+	@TOKEN=$$($(MAKE) token 2>/dev/null | tail -1); \
+	if [[ $$TOKEN == Bearer* ]]; then \
+		echo "✅ Got token: $${TOKEN:0:50}..."; \
+		echo "Testing protected endpoint:"; \
+		curl -s -H "Authorization: $$TOKEN" http://localhost:8000/api/protected/ | python -m json.tool 2>/dev/null || echo "❌ Django not running"; \
+	else \
+		echo "❌ Failed to get token"; \
+	fi
+
+test-integration: ## Run complete integration test with docker
+	@echo "🧪 Running integration test with docker..."
+	@python scripts/test-integration.py

--- a/test_project/README.md
+++ b/test_project/README.md
@@ -1,0 +1,84 @@
+# DRF Keycloak Testing
+
+Quick testing setup for the DRF Keycloak package with real Keycloak integration.
+
+⚠️ **Note**: This test project is **not shipped with the package** (excluded in `setup.py`).
+
+## Quick Start
+
+```bash
+# Option 1: Complete automated test (recommended)
+make test-integration
+
+# Option 2: Step by step manual testing  
+make start-keycloak      # Wait 1-2 minutes for Keycloak to start
+make setup-keycloak      # Configure realm and test users
+make start-django        # Start Django (in separate terminal)
+make curl-test           # Test endpoints
+```
+
+## Available Commands
+
+| Command | Dependencies | Description |
+|---------|--------------|-------------|
+| `make help` | none | Show all commands |
+| `make quickstart` | none | Show detailed guide |
+| `make test-unit` | none | Run unit tests |
+| `make install` | none | Install package in venv |
+| `make clean` | none | Stop containers and cleanup |
+| `make start-keycloak` | Docker | Start Keycloak in Docker |
+| `make setup-keycloak` | ↳ start-keycloak | Configure realm and test data |
+| `make token` | ↳ setup-keycloak | Get test token from Keycloak |
+| `make start-django` | ↳ setup-keycloak | Start Django test server |
+| `make curl-test` | ↳ start-django | Test API endpoints |
+| `make test-integration` | Docker | Full automated test |
+
+## Test Endpoints
+
+| Endpoint | Authentication | Description |
+|----------|----------------|-------------|
+| `/api/public/` | None | Public endpoint |
+| `/api/protected/` | JWT Token | Requires authentication |
+| `/api/profile/` | JWT + Permission | Requires 'view-profile' permission |
+
+**Test Credentials:**
+- Username: `testuser`
+- Password: `testpass`
+- Realm: `test-realm`
+- Client: `test-client`
+
+## Manual Testing
+
+### 1. Get Access Token
+```bash
+make token
+```
+
+### 2. Test Endpoints
+```bash
+# Public endpoint (no auth)
+curl http://localhost:8000/api/public/
+
+# Protected endpoint without token (should return 401)
+curl http://localhost:8000/api/protected/
+
+# Protected endpoint with token
+TOKEN=$(make token | tail -1)
+curl -H "Authorization: $TOKEN" http://localhost:8000/api/protected/
+
+# Permission endpoint
+curl -H "Authorization: $TOKEN" http://localhost:8000/api/profile/
+```
+
+### 3. Keycloak Admin Console
+- URL: http://localhost:8080
+- Login: `admin` / `admin`
+
+## Cleanup
+
+```bash
+# Stop all containers and remove volumes
+make clean
+```
+
+This is a minimal setup for quick testing. For production use, refer to the main package documentation.

--- a/test_project/apps.py
+++ b/test_project/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class TestProjectConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'test_project'

--- a/test_project/docker-compose.test.yml
+++ b/test_project/docker-compose.test.yml
@@ -1,0 +1,40 @@
+version: '3.3'
+
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB: dev-file
+    ports:
+      - "8080:8080"
+    command:
+      - start-dev
+    volumes:
+      - keycloak_data:/opt/keycloak/data
+
+  test-backend:
+    build: 
+      context: ..
+      dockerfile: test_project/Dockerfile
+    environment:
+      - KEYCLOAK_SERVER_URL=http://keycloak:8080/realms/test-realm
+      - KEYCLOAK_REALM=test-realm
+      - KEYCLOAK_ISSUER=http://localhost:8080/realms/test-realm
+      - PYTHONPATH=/app
+    depends_on:
+      - keycloak
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app/test_project
+      - ..:/app
+    working_dir: /app
+    command: >
+      sh -c "pip install PyJWT && cd test_project && 
+             python manage.py migrate &&
+             python manage.py runserver 0.0.0.0:8000"
+
+volumes:
+  keycloak_data:

--- a/test_project/manage.py
+++ b/test_project/manage.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)

--- a/test_project/scripts/setup-keycloak.sh
+++ b/test_project/scripts/setup-keycloak.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Script to setup Keycloak for testing
+set -e
+
+KEYCLOAK_URL="http://localhost:8080"
+ADMIN_USER="admin"
+ADMIN_PASS="admin"
+REALM_NAME="test-realm"
+CLIENT_ID="test-client"
+
+echo "🔧 Setting up Keycloak for testing..."
+
+# Wait for Keycloak to be ready
+echo "⏳ Waiting for Keycloak to start..."
+timeout=60
+counter=0
+until curl -f "$KEYCLOAK_URL/realms/master" > /dev/null 2>&1; do
+    sleep 3
+    counter=$((counter + 3))
+    if [ $counter -gt $timeout ]; then
+        echo "❌ Timeout waiting for Keycloak after ${timeout}s"
+        exit 1
+    fi
+    echo "   ... still waiting (${counter}s)"
+done
+echo "✅ Keycloak is ready!"
+
+# Get admin token
+echo "🔑 Getting admin token..."
+ADMIN_TOKEN=$(curl -s -X POST "$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=$ADMIN_USER" \
+  -d "password=$ADMIN_PASS" \
+  -d "grant_type=password" \
+  -d "client_id=admin-cli" | \
+  python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
+
+echo "✅ Admin token obtained"
+
+# Create realm
+echo "🏗️  Creating realm: $REALM_NAME"
+curl -s -X POST "$KEYCLOAK_URL/admin/realms" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "realm": "'$REALM_NAME'",
+    "enabled": true,
+    "displayName": "Test Realm for DRF Keycloak"
+  }' || echo "Realm might already exist"
+
+# Create client
+echo "🔧 Creating client: $CLIENT_ID"
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/$REALM_NAME/clients" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "'$CLIENT_ID'",
+    "enabled": true,
+    "publicClient": true,
+    "directAccessGrantsEnabled": true,
+    "protocol": "openid-connect",
+    "standardFlowEnabled": false,
+    "implicitFlowEnabled": false,
+    "directAccessGrantsEnabled": true,
+    "serviceAccountsEnabled": false,
+    "attributes": {
+      "jwt.credential": "true"
+    }
+  }' || echo "Client might already exist"
+
+# Create test user
+echo "👤 Creating test user..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/$REALM_NAME/users" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "testuser",
+    "enabled": true,
+    "firstName": "Test",
+    "lastName": "User",
+    "email": "test@example.com",
+    "credentials": [{
+      "type": "password",
+      "value": "testpass",
+      "temporary": false
+    }]
+  }' || echo "User might already exist"
+
+# Create roles
+echo "🛡️  Creating roles..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/$REALM_NAME/roles" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "view-profile",
+    "description": "Can view profile"
+  }' || echo "Role might already exist"
+
+echo "✅ Keycloak setup complete!"
+echo ""
+echo "📋 Test Configuration:"
+echo "   Realm: $REALM_NAME"
+echo "   Client ID: $CLIENT_ID"
+echo "   Test User: testuser / testpass"
+echo "   JWKS URL: $KEYCLOAK_URL/realms/$REALM_NAME/protocol/openid-connect/certs"
+echo ""
+echo "🧪 To get a test token:"
+echo "   curl -X POST '$KEYCLOAK_URL/realms/$REALM_NAME/protocol/openid-connect/token' \\"
+echo "     -H 'Content-Type: application/x-www-form-urlencoded' \\"
+echo "     -d 'username=testuser' \\"
+echo "     -d 'password=testpass' \\"
+echo "     -d 'grant_type=password' \\"
+echo "     -d 'client_id=$CLIENT_ID'"

--- a/test_project/scripts/test-integration.py
+++ b/test_project/scripts/test-integration.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Integration test script for DRF Keycloak package
+"""
+import requests
+import json
+import sys
+import time
+
+KEYCLOAK_URL = "http://localhost:8080"
+DJANGO_URL = "http://localhost:8000"
+REALM = "test-realm"
+CLIENT_ID = "test-client"
+USERNAME = "testuser"
+PASSWORD = "testpass"
+
+def get_access_token():
+    """Get access token from Keycloak"""
+    print("🔑 Getting access token from Keycloak...")
+    
+    token_url = f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/token"
+    data = {
+        'username': USERNAME,
+        'password': PASSWORD,
+        'grant_type': 'password',
+        'client_id': CLIENT_ID
+    }
+    
+    try:
+        response = requests.post(token_url, data=data)
+        response.raise_for_status()
+        token_data = response.json()
+        print("✅ Token obtained successfully")
+        return token_data['access_token']
+    except Exception as e:
+        print(f"❌ Failed to get token: {e} Ensure Keycloak is running and credentials und User are correct?")
+        return None
+
+def test_public_endpoint():
+    """Test public endpoint (no auth required)"""
+    print("\n🌍 Testing public endpoint...")
+    
+    try:
+        response = requests.get(f"{DJANGO_URL}/api/public/")
+        response.raise_for_status()
+        data = response.json()
+        print(f"✅ Public endpoint response: {data}")
+        return True
+    except Exception as e:
+        print(f"❌ Public endpoint failed: {e}")
+        return False
+
+def test_protected_endpoint(token):
+    """Test protected endpoint (auth required)"""
+    print("\n🔒 Testing protected endpoint...")
+    
+    headers = {'Authorization': f'Bearer {token}'}
+    
+    try:
+        response = requests.get(f"{DJANGO_URL}/api/protected/", headers=headers)
+        response.raise_for_status()
+        data = response.json()
+        print(f"✅ Protected endpoint response: {json.dumps(data, indent=2)}")
+        return True
+    except Exception as e:
+        print(f"❌ Protected endpoint failed: {e}")
+        return False
+
+def test_protected_endpoint_without_token():
+    """Test protected endpoint without token (should fail)"""
+    print("\n🚫 Testing protected endpoint without token...")
+    
+    try:
+        response = requests.get(f"{DJANGO_URL}/api/protected/")
+        if response.status_code == 401:
+            print("✅ Correctly rejected request without token")
+            return True
+        else:
+            print(f"❌ Expected 401, got {response.status_code}")
+            return False
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        return False
+
+def test_permission_endpoint(token):
+    """Test endpoint requiring specific permission"""
+    print("\n🛡️  Testing permission-protected endpoint...")
+    
+    headers = {'Authorization': f'Bearer {token}'}
+    
+    try:
+        response = requests.get(f"{DJANGO_URL}/api/profile/", headers=headers)
+        print(f"📋 Profile endpoint status: {response.status_code}")
+        
+        if response.status_code == 200:
+            data = response.json()
+            print(f"✅ Profile endpoint response: {json.dumps(data, indent=2)}")
+            return True
+        elif response.status_code == 403:
+            print("⚠️  Access denied - user doesn't have 'view-profile' permission")
+            print("   This is expected if the user role hasn't been assigned")
+            return True
+        else:
+            print(f"❌ Unexpected status: {response.status_code}")
+            return False
+    except Exception as e:
+        print(f"❌ Permission endpoint failed: {e}")
+        return False
+
+def main():
+    """Run all integration tests"""
+    print("🧪 Starting DRF Keycloak Integration Tests")
+    print("=" * 50)
+    
+    # Wait for services to be ready
+    print("⏳ Waiting for services to be ready...")
+    time.sleep(2)
+    
+    results = []
+    
+    # Test 1: Public endpoint
+    results.append(test_public_endpoint())
+    
+    # Test 2: Get token
+    token = get_access_token()
+    if not token:
+        print("❌ Cannot continue without token")
+        sys.exit(1)
+    
+    # Test 3: Protected endpoint with token
+    results.append(test_protected_endpoint(token))
+    
+    # Test 4: Protected endpoint without token
+    results.append(test_protected_endpoint_without_token())
+    
+    # Test 5: Permission endpoint
+    results.append(test_permission_endpoint(token))
+    
+    # Summary
+    print("\n" + "=" * 50)
+    print("📊 Test Summary:")
+    passed = sum(results)
+    total = len(results)
+    
+    print(f"   ✅ Passed: {passed}/{total}")
+    
+    if passed == total:
+        print("🎉 All tests passed!")
+        sys.exit(0)
+    else:
+        print("❌ Some tests failed!")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -1,0 +1,109 @@
+"""
+Django settings for test_project.
+"""
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = 'django-insecure-test-key-for-testing-only'
+
+DEBUG = True
+
+ALLOWED_HOSTS = ['*']
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'drf_keycloak',
+    'test_project',
+]
+
+MIDDLEWARE = [
+    'drf_keycloak.middleware.HeaderMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'test_project.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'drf_keycloak.authentication.KeycloakAuthBackend',
+        'rest_framework.authentication.SessionAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
+}
+
+# Keycloak Configuration
+KEYCLOAK_CONFIG = {
+    'SERVER_URL': os.environ.get('KEYCLOAK_SERVER_URL', 'http://localhost:8080/realms/test-realm'),
+    'REALM': os.environ.get('KEYCLOAK_REALM', 'test-realm'),
+    'CLIENT_ID': os.environ.get('KEYCLOAK_CLIENT_ID', 'test-client'),
+    'CLIENT_SECRET': os.environ.get('KEYCLOAK_CLIENT_SECRET', None),
+    'AUDIENCE': os.environ.get('KEYCLOAK_AUDIENCE', None),
+    'ISSUER': os.environ.get('KEYCLOAK_ISSUER', 'http://localhost:8080/realms/test-realm'),
+}
+
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = 'static/'
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+    },
+    'loggers': {
+        'drf_keycloak': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+    },
+}

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,0 +1,56 @@
+"""
+URL configuration for test_project.
+"""
+from django.contrib import admin
+from django.urls import path, include
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from drf_keycloak.permissions import HasPermission
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def protected_view(request):
+    """A simple protected view that requires authentication"""
+    return Response({
+        'message': 'Hello, authenticated user!',
+        'user': request.user.username,
+        'user_data': {
+            'id': request.user.id,
+            'username': request.user.username,
+            'email': request.user.email,
+            'first_name': request.user.first_name,
+            'last_name': request.user.last_name,
+            'is_active': request.user.is_active,
+        },
+        'token_payload': request.auth if hasattr(request, 'auth') else None
+    })
+
+class ViewProfilePermission(HasPermission):
+    permission = "view-profile"
+
+@api_view(['GET'])
+@permission_classes([ViewProfilePermission])
+def profile_view(request):
+    """A view that requires the 'view-profile' permission"""
+    return Response({
+        'message': 'You have view-profile permission!',
+        'user': request.user.username,
+        'permissions': request.auth.get('resource_access', {}) if request.auth else {}
+    })
+
+@api_view(['GET'])
+@permission_classes([])  # No permissions required
+def public_view(request):
+    """A public view that doesn't require authentication"""
+    return Response({
+        'message': 'This is a public endpoint',
+        'authenticated': request.user.is_authenticated if hasattr(request, 'user') else False
+    })
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('api/public/', public_view, name='public'),
+    path('api/protected/', protected_view, name='protected'),
+    path('api/profile/', profile_view, name='profile'),
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ def pytest_configure():
             }
         },
         INSTALLED_APPS=[
-            # Füge hier die Namen der Django-Apps hinzu, die für deine Tests benötigt werden
             'django.contrib.auth',
             'django.contrib.contenttypes',
             'django.contrib.sessions',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,7 +12,6 @@ class KeycloakSettingsTestCase(TestCase):
         self.assertEqual(keycloak_settings.CLIENT_ID, 'account')
         self.assertIsNone(keycloak_settings.CLIENT_SECRET)
         self.assertIsNone(keycloak_settings.AUDIENCE)
-        self.assertFalse(keycloak_settings.VERIFY_TOKENS_WITH_KEYCLOAK)
         self.assertEqual(keycloak_settings.PERMISSION_PATH, "resource_access.account.roles")
         self.assertEqual(keycloak_settings.USER_ID_FIELD, "username")
         self.assertEqual(keycloak_settings.USER_ID_CLAIM, "preferred_username")

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,76 +1,44 @@
 """ tests for token functions """
 from unittest import mock
 
-import jwt
-from django.test import SimpleTestCase, TestCase
-from django.test.utils import override_settings
-from rest_framework.exceptions import APIException
+from django.test import TestCase
 
 import drf_keycloak.token as token_model
-from drf_keycloak.token import JWToken, TokenError
+from drf_keycloak.token import JWToken
+from drf_keycloak.exceptions import TokenBackendError
 
 
 class TestKeycloakToken(TestCase):
     def setUp(self):
         token_model.PUBLIC_KEYCLOAK_KEY_CACHE = None
 
-    @override_settings(KEYCLOAK_CONFIG={"VERIFY_TOKENS_WITH_KEYCLOAK": False})
     @mock.patch("drf_keycloak.api.KeycloakApi.get_public_key")
     def test_get_public_key(self, mock_get_public_key):
         mock_get_public_key.return_value = "test"
         token_instance = JWToken()
         self.assertEqual("test", token_instance.get_jwt_key())
 
-    @override_settings(KEYCLOAK_CONFIG={"VERIFY_TOKENS_WITH_KEYCLOAK": False})
     def test_get_public_key_from_cache(self):
         token_model.PUBLIC_KEYCLOAK_KEY_CACHE = "test"
         token_instance = JWToken()
         self.assertEqual("test", token_instance.get_jwt_key())
 
-    @override_settings(KEYCLOAK_CONFIG={"VERIFY_TOKENS_WITH_KEYCLOAK": False})
     @mock.patch("drf_keycloak.api.KeycloakApi.get_public_key")
     @mock.patch("drf_keycloak.api.KeycloakApi.get_jwks")
     def test_decode(self, mock_get_jwt_key, mock_public_key):
         mock_public_key.return_value = "super"
         mock_get_jwt_key.return_value = "abc"
-        token = jwt.encode(
-            payload={
-                "iss": "test",
-            },
-            key="abc",
-        )
-        with self.assertRaises(TokenError) as error:
+        # Test with invalid token (malformed)
+        token = "invalid.token.here"
+        with self.assertRaises(TokenBackendError) as error:
             JWToken(token)
-        self.assertEqual("Invalid algorithm specified", str(error.exception))
+        self.assertEqual("Token is invalid", str(error.exception))
         token = (
             "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ6bEtLcFJmU2FBY"
             "lhrakl0cmhZMnFSMEZLZFVsbTZMSjh1Q3Rzb3VyV1JFIn0"
         )
-        with self.assertRaises(TokenError) as error:
+        with self.assertRaises(TokenBackendError) as error:
             JWToken(token)
-        self.assertEqual("Token is invalid or expired", str(error.exception))
+        self.assertEqual("Token is invalid", str(error.exception))
 
 
-class TestKeycloakTokenVerifyTokensWithKeycloak(SimpleTestCase):
-    @override_settings(KEYCLOAK_CONFIG={"VERIFY_TOKENS_WITH_KEYCLOAK": True})
-    @mock.patch("drf_keycloak.token.JWToken.decode")
-    @mock.patch("drf_keycloak.api.KeycloakApi.get_introspect")
-    @mock.patch("drf_keycloak.api.KeycloakApi.get_jwks")
-    def test_verify_token_with_keycloak(self, mock_get_jwks, mock_get_introspect, mock_decode):
-        mock_get_jwks.return_value = "key"
-        mock_decode.return_value = {"key": "value"}
-        mock_get_introspect.return_value = {"active": True}
-        token_instance = JWToken("test")
-        self.assertEqual(token_instance.payload, {"key": "value"})
-
-        mock_get_introspect.return_value = {"active": False}
-        with self.assertRaises(APIException) as error:
-            JWToken("test")
-        self.assertIn("False", str(error.exception))
-
-    @override_settings(KEYCLOAK_CONFIG={"VERIFY_TOKENS_WITH_KEYCLOAK": True})
-    @mock.patch("drf_keycloak.api.KeycloakApi.get_jwks")
-    def test_get_jwks(self, mock_get_jwks):
-        mock_get_jwks.return_value = "test"
-        token_instance = JWToken()
-        self.assertEqual("test", token_instance.get_jwt_key())

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
     py{37,38,39,310}-dj{32}-drf{311,312,313}-pyjwt{2}-tests
-    py{38,39,310}-dj{40,41}-drf313-pyjwt{2}-tests
-    py311-dj{41,42}-drf314-pyjwt{2}-tests
+    py{38,39,310,311}-dj{40,41,42}-drf313-pyjwt{2}-tests
+    py{311,312}-dj{42,50,51}-drf314-pyjwt{2}-tests
 
 [gh-actions]
 python=
@@ -11,6 +11,7 @@ python=
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 DJANGO=
@@ -18,6 +19,8 @@ DJANGO=
     4.0: dj40
     4.1: dj41
     4.2: dj42
+    5.0: dj50
+    5.1: dj51
 DRF=
     3.10: drf310
     3.11: drf311
@@ -37,6 +40,8 @@ deps=
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
+    dj50: Django>=5.0,<5.1
+    dj51: Django>=5.1,<5.2
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13


### PR DESCRIPTION
- Support for `raw_token` as both `bytes` and `str` in `KeycloakAuthBackend`.
- New tests that cover both token types.
- **Docker Test Environment:** Complete Docker setup with Keycloak integration for testing
- **Integration Tests:** Comprehensive test scripts to validate authentication flow
- **SERVER_URL Configuration:** New `SERVER_URL` setting to separate API calls from JWT issuer validation
- **Custom Exception Classes:** Added `TokenBackendError` and `TokenBackendExpiredToken` for better error handling